### PR TITLE
updateMetadataForTrack fix

### DIFF
--- a/ios/RNTrackPlayer/RNTrackPlayerBridge.m
+++ b/ios/RNTrackPlayer/RNTrackPlayerBridge.m
@@ -96,7 +96,7 @@ RCT_EXTERN_METHOD(getState:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject);
 
 RCT_EXTERN_METHOD(updateMetadataForTrack:(NSString *)trackId
-                  withProperties:(NSDictionary *)properties
+                  properties:(NSDictionary *)properties
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject);
 


### PR DESCRIPTION
The fix change "withProperties" method name to "properties" method name, which is the right instance.